### PR TITLE
hide importance if is everthing ok

### DIFF
--- a/src/Observer.php
+++ b/src/Observer.php
@@ -85,10 +85,11 @@ Class Observer implements iObserver {
       $eye->checkRequirement();
       $eye->look();
 
+      $code = $eye->getStatusCode();
+
       $return = [
-        'status' => $eye->getStatusCode(),
+        'status' => $code,
         'message' => $eye->getMessage(),
-        $this->importance_alias => empty($conf['importance'])? $this->importance_default : $conf['importance']
       ];
 
     } catch (Exception $ex){
@@ -99,10 +100,12 @@ Class Observer implements iObserver {
       $return = [
           'status' =>  $code,
           'message' => $ex->getMessage(),
-          $this->importance_alias => empty($conf['importance'])? $this->importance_default : $conf['importance']
       ];
 
     }
+
+    if($code !== 200)
+        $return[$this->importance_alias] = empty($conf['importance'])? $this->importance_default : $conf['importance'];
 
     return $return;
 

--- a/src/Observer.php
+++ b/src/Observer.php
@@ -17,8 +17,8 @@ Class Observer implements iObserver {
   protected $env;
   protected $start;
 
-  protected $importance_alias;
-  protected $importance_default;
+  protected $importanceAlias;
+  protected $importanceDefault;
 
   protected $timezone;
 
@@ -31,7 +31,6 @@ Class Observer implements iObserver {
 
   public function __construct(){
     $this->start = microtime();
-
   }
 
   public function setConf($conf){
@@ -105,7 +104,7 @@ Class Observer implements iObserver {
     }
 
     if($code !== 200)
-        $return[$this->importance_alias] = empty($conf['importance'])? $this->importance_default : $conf['importance'];
+        $return[$this->importanceAlias] = empty($conf['importance'])? $this->importanceDefault : $conf['importance'];
 
     return $return;
 
@@ -136,17 +135,17 @@ Class Observer implements iObserver {
 
   protected function applyImportanceAlias(){
     if(empty($this->conf['settings']['importance_alias'])){
-      $this->importance_alias = self::IMPORTANCE_ALIAS;
+      $this->importanceAlias = self::IMPORTANCE_ALIAS;
     } else {
-      $this->importance_alias = $this->conf['settings']['importance_alias'];
+      $this->importanceAlias = $this->conf['settings']['importance_alias'];
     }
   }
 
   protected function applyImportanceDefault(){
     if(empty($this->conf['settings']['importance_default'])){
-      $this->importance_default = self::IMPORTANCE_DEFAULT;
+      $this->importanceDefault = self::IMPORTANCE_DEFAULT;
     } else {
-      $this->importance_default = $this->conf['settings']['importance_default'];
+      $this->importanceDefault = $this->conf['settings']['importance_default'];
     }
   }
 

--- a/tests/unit/ObserverTest.php
+++ b/tests/unit/ObserverTest.php
@@ -115,7 +115,6 @@ class ObserverTest extends \Codeception\Test\Unit
       $this->assertEquals($result[$eyeName]['importance'], HelperObserver::IMPORTANCE_DEFAULT);
 
     }
-
     public function testOverviewWhenASingleGoesRight(){
 
       $path = '/mnt/read';
@@ -141,6 +140,7 @@ class ObserverTest extends \Codeception\Test\Unit
       $beholder->run();
       $result = $beholder->getResult();
       $this->assertEquals($result['info']['overview'], HelperObserver::OVERVIEW_OK);
+      $this->assertArrayNotHasKey('importance', $result[$eyeName]);
 
     }
 
@@ -207,7 +207,7 @@ class ObserverTest extends \Codeception\Test\Unit
       $beholder->run();
       $result = $beholder->getResult();
       $this->assertEquals($result['info']['overview'], HelperObserver::SOMETHING_IS_WRONG);
-
+      $this->assertArrayHasKey('importance', $result[$eyeName]);
     }
 
     public function testOverviewWhenAMultipleGoesWrong(){

--- a/tests/unit/fixtures/HelperObserver.php
+++ b/tests/unit/fixtures/HelperObserver.php
@@ -7,11 +7,11 @@ require_once '/var/www/vendor/autoload.php';
 class HelperObserver  extends Observer {
 
   public function getImportanceAlias(){
-    return $this->importance_alias;
+    return $this->importanceAlias;
   }
 
   public function getImportanceDefault(){
-    return $this->importance_default;
+    return $this->importanceDefault;
   }
 
   public function getTimeZone(){


### PR DESCRIPTION
Importance is showing all the time, I thought it is can cause confusion.
Exemple: This is right, but have on "system-down" on it.

connect-datbase: {
status: 200,
message: "Ok",
importance: "system-down"
},

With this change it will be like:

connect-datbase: {
status: 200,
message: "Ok"
},

or 

connect-datbase: {
status: 600,
message: "Could not connect to SGBD",
importance: "system-down"
},